### PR TITLE
Fix for empty data returned after new Fritz!Box 7490 update

### DIFF
--- a/fritz_switch_profiles/fritz_switch_profiles.py
+++ b/fritz_switch_profiles/fritz_switch_profiles.py
@@ -113,7 +113,7 @@ class FritzProfileSwitch:
         url = self.url + "/data.lua"
         response = requests.post(url, data=data, allow_redirects=True)
         json = response.json()
-        if("data" in json and "active" not in json["data"]):
+        if "data" in json and "active" not in json["data"]:
             data["xhrId"] = "all"
             response = requests.post(url, data=data, allow_redirects=True)
             json = response.json()

--- a/fritz_switch_profiles/fritz_switch_profiles.py
+++ b/fritz_switch_profiles/fritz_switch_profiles.py
@@ -109,10 +109,14 @@ class FritzProfileSwitch:
     def fetch_devices(self):
         """Fetch and store all devices"""
         logging.info("FETCHING DEVICES...")
-        data = {"xhr": 1, "sid": self.sid, "no_sidrenew": "", "xhrId": "all", "page": "netDev"}
+        data = {"xhr": 1, "sid": self.sid, "no_sidrenew": "", "page": "netDev"}
         url = self.url + "/data.lua"
         response = requests.post(url, data=data, allow_redirects=True)
         json = response.json()
+        if("data" in json and "active" not in json["data"]):
+            data["xhrId"] = "all"
+            response = requests.post(url, data=data, allow_redirects=True)
+            json = response.json()
         self.devices = []
         if "data" in json and "active" in json["data"]:
             for device in json["data"]["active"]:

--- a/fritz_switch_profiles/fritz_switch_profiles.py
+++ b/fritz_switch_profiles/fritz_switch_profiles.py
@@ -109,7 +109,7 @@ class FritzProfileSwitch:
     def fetch_devices(self):
         """Fetch and store all devices"""
         logging.info("FETCHING DEVICES...")
-        data = {"xhr": 1, "sid": self.sid, "no_sidrenew": "",'xhrId': 'all', "page": "netDev"}
+        data = {"xhr": 1, "sid": self.sid, "no_sidrenew": "", "xhrId": "all", "page": "netDev"}
         url = self.url + "/data.lua"
         response = requests.post(url, data=data, allow_redirects=True)
         json = response.json()

--- a/fritz_switch_profiles/fritz_switch_profiles.py
+++ b/fritz_switch_profiles/fritz_switch_profiles.py
@@ -109,7 +109,7 @@ class FritzProfileSwitch:
     def fetch_devices(self):
         """Fetch and store all devices"""
         logging.info("FETCHING DEVICES...")
-        data = {"xhr": 1, "sid": self.sid, "no_sidrenew": "", "page": "netDev"}
+        data = {"xhr": 1, "sid": self.sid, "no_sidrenew": "",'xhrId': 'all', "page": "netDev"}
         url = self.url + "/data.lua"
         response = requests.post(url, data=data, allow_redirects=True)
         json = response.json()


### PR DESCRIPTION
Fixes this error:
  File "/usr/local/lib/python3.8/dist-packages/fritz_switch_profiles/fritz_switch_profiles.py", line 25, in __init__
    self.fetch_devices()
  File "/usr/local/lib/python3.8/dist-packages/fritz_switch_profiles/fritz_switch_profiles.py", line 116, in fetch_devices
    for device in j['data']['active']:
TypeError: list indices must be integers or slices, not str